### PR TITLE
Fix custom font/requires issue

### DIFF
--- a/js/figwheel-bridge.js
+++ b/js/figwheel-bridge.js
@@ -16,6 +16,7 @@ var config = {
 var React = require('react');
 var createReactClass = require('create-react-class');
 var ReactNative = require('react-native');
+var Expo = require('expo');
 var WebSocket = require('WebSocket');
 var self;
 var evaluate = eval; // This is needed, direct calls to eval does not work (RN packager???)
@@ -219,8 +220,7 @@ function loadApp(platform, devHost, onLoadCb) {
 }
 
 function startApp(appName, platform, devHost) {
-    ReactNative.AppRegistry.registerComponent(
-        appName, () => figwheelApp(platform, devHost));
+    Expo.registerRootComponent(figwheelApp(platform, devHost));
 }
 
 function withModules(moduleById) {

--- a/src/app/core.cljs
+++ b/src/app/core.cljs
@@ -117,10 +117,10 @@
               "hey pacifico"]
 
              [text {:style {:font-size 25
-                            :font-family "serif"
+                            :font-family "Helvetica"
                             :padding-top 8
                             :padding-bottom 8}}
-              "hey serif"]
+              "hey helvetica"]
 
              [<fontawesome-icon> {:name "camera" :size 30}]
 
@@ -132,4 +132,4 @@
 
 (defn init []
   (dispatch-sync [:initialize-db])
-  (.registerComponent app-registry "main" #(r/reactify-component app-root)))
+  (.registerRootComponent Expo (r/reactify-component app-root)))


### PR DESCRIPTION
I also had this problem, and realised that the Expo `registerRootComponent` does some additional work for fonts to function properly that the standard React Native `registerComponent` doesn't do. 

See these lines 
```https://github.com/expo/expo-sdk/blob/73d8957958546b309238a94e76836981db30911e/src/launch/registerRootComponent.js#L21-L30```

Try out this PR and see if it works. 
